### PR TITLE
Fix server module type and document running demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ trackOffset.currentTime; // time in track
 When modifying the repository, to create appropriate TypeScript types and
 JavaScript bundles, use `npm run compile`.
 
+## Running the demo server
+
+This repository also includes a simple Express application for recording audio
+in the browser and submitting it to OpenAI for transcription and summarization.
+To start the server locally:
+
+```bash
+npm install
+npm start
+```
+
+By default the server runs on port `3000`. Make sure your `OPENAI_API_KEY`
+environment variable is set before starting so that requests to the OpenAI API
+succeed.
+
 # Acknowledgements and contact
 
 Thanks to the OpenAI Realtime team! Without their awesome work this library would not

--- a/server.js
+++ b/server.js
@@ -1,8 +1,13 @@
-const express = require('express');
-const multer = require('multer');
-const fs = require('fs');
-const path = require('path');
-const fetch = require('node-fetch');
+import express from 'express';
+import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import fetch from 'node-fetch';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const upload = multer({ dest: 'uploads/' });
 const app = express();


### PR DESCRIPTION
## Summary
- convert server.js to use ES module syntax so Node can run with `type: module`
- document how to run the example Express server

## Testing
- `npm run compile`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685572064e2083229ce2cec4fa596f55