### PR TITLE
Improve transcript automation and UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,26 +1,76 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Audio Transcriber & Summarizer</title>
-<style>
-body { font-family: Arial, sans-serif; margin: 40px; }
-button { margin-right: 10px; }
-textarea { width: 100%; height: 150px; margin-top: 10px; }
-</style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Audio Transcriber & Summarizer</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
+    rel="stylesheet"
+  />
 </head>
-<body>
-<h1>Audio Transcriber & Summarizer</h1>
-<div>
-  <button id="recordBtn">Start Recording</button>
-  <button id="stopBtn" disabled>Stop Recording</button>
-  <button id="transcribeBtn" disabled>Transcribe</button>
-</div>
-<textarea id="transcript" placeholder="Transcript will appear here..."></textarea>
-<button id="copyTranscript" disabled>Copy Transcript</button>
-<textarea id="summary" placeholder="Summary will appear here..."></textarea>
-<button id="copySummary" disabled>Copy Summary</button>
-<script src="main.js"></script>
+<body class="p-8 bg-gray-100 font-sans">
+  <h1 class="text-2xl font-bold mb-4">Audio Transcriber &amp; Summarizer</h1>
+  <div class="flex gap-2 mb-4">
+    <button
+      id="recordBtn"
+      class="px-4 py-2 rounded bg-blue-500 text-white"
+    >
+      Start Recording
+    </button>
+    <button
+      id="stopBtn"
+      class="px-4 py-2 rounded bg-red-500 text-white"
+      disabled
+    >
+      Stop Recording
+    </button>
+    <button
+      id="summarizeBtn"
+      class="px-4 py-2 rounded bg-green-500 text-white"
+      disabled
+    >
+      Generate SOAP Notes
+    </button>
+  </div>
+
+  <textarea
+    id="transcript"
+    class="w-full h-40 p-2 border rounded mb-2"
+    placeholder="Transcript will appear here..."
+    readonly
+  ></textarea>
+  <div class="flex gap-2 mb-4">
+    <button
+      id="copyTranscript"
+      class="px-4 py-2 rounded bg-gray-200"
+      disabled
+    >
+      Copy Transcript
+    </button>
+    <button
+      id="copySummary"
+      class="px-4 py-2 rounded bg-gray-200"
+      disabled
+    >
+      Copy Summary
+    </button>
+    <button
+      id="copyBoth"
+      class="px-4 py-2 rounded bg-gray-200"
+      disabled
+    >
+      Copy Both
+    </button>
+  </div>
+
+  <textarea
+    id="summary"
+    class="w-full h-40 p-2 border rounded mb-2"
+    placeholder="Summary will appear here..."
+    readonly
+  ></textarea>
+
+  <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- automate audio transcription when recording stops
- move SOAP note generation behind button
- add copy both button and Tailwind-based styles

## Testing
- `npm run compile`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855790820e4832296a0043dabee88af