### PR TITLE
Support chunked webm recording

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ app.post('/api/transcribe', upload.single('audio'), async (req, res) => {
       return res.status(500).json({ error: 'Missing OPENAI_API_KEY' });
     }
     const form = new FormData();
-    form.append('file', fs.createReadStream(filePath), 'audio.wav');
+    form.append('file', fs.createReadStream(filePath), 'audio.webm');
     form.append('model', 'whisper-1');
     const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- stream microphone audio in `audio/webm` chunks using `MediaRecorder`
- send each chunk for transcription immediately
- forward received webm chunks to OpenAI when transcribing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855d2fd861883228e0ea04e36c8c3ed